### PR TITLE
fix: deployment annotations nesting

### DIFF
--- a/stable/gotenberg/templates/deployment.yaml
+++ b/stable/gotenberg/templates/deployment.yaml
@@ -22,8 +22,8 @@ spec:
       labels:
         app: {{ template "gotenberg.name" . }}
         release: {{ .Release.Name }}
-    annotations:
-      checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
       securityContext:
         runAsUser: 1001


### PR DESCRIPTION
sorry, the last PR screwed the deployment spec due to wrongly nested `annotations` field